### PR TITLE
Fix output for date.php

### DIFF
--- a/date.php
+++ b/date.php
@@ -1,9 +1,8 @@
+<?php
 // Copyright 2020 gyroninja
 // This program is licensed under the CC0 1.0 Universal license
 // https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt
 // This is a reimplementation of date.php that
 // returns a UNIX timestamp in seconds
-<?php
-echo "currentdate=" . (new DateTime())->getTimestamp()
+echo "currentdate=" . (new DateTime())->getTimestamp() . "\n"
 ?>
-


### PR DESCRIPTION
Previously the comments along with the new line at the end of the file
were being printed. This change will make the output solely come from
the single echo statement.